### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You'll need:
  - if you choose clang, change build.sh as described in there
  - libusb 1.0, including development files
    - on Ubuntu/Debian this can be achieved via `sudo apt-get install libusb-1.0-0-dev`
+ - pkg-config, if not already installed
+   - on Ubuntu/Debian this can be achieved via `sudo apt-get install pkg-config`
 
 Then, on a regular Linux System just type `./build.sh` and it should work.
 If it does not, look at the script and adapt the path accordingly.


### PR DESCRIPTION
Documented a fix for when the build process can not find libusb-1.0:

    -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) 
    -- Checking for one of the modules 'libusb-1.0'
    CMake Error at /usr/share/cmake-3.10/Modules/FindPkgConfig.cmake:645 (message):
      None of the required 'libusb-1.0' found